### PR TITLE
Fix misordered args when calling a formatted logging function

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -45,9 +45,9 @@ func (e *Entry) toJSON() []byte {
 }
 
 func makeEntry(level Level, args []interface{}) *Entry {
-	fields, remaining := extractAllFields(args)
+	fields, remaining := ExtractAllFields(args)
 
-	message := renderMessage(remaining...)
+	message := RenderMessage(remaining...)
 
 	return &Entry{
 		time.Now().UTC(),
@@ -60,7 +60,7 @@ func makeEntry(level Level, args []interface{}) *Entry {
 func makeFormattedEntry(
 	level Level, pattern string, args []interface{},
 ) *Entry {
-	fields, remaining := extractTrailingFields(args)
+	fields, remaining := ExtractTrailingFields(args)
 
 	message := fmt.Sprintf(pattern, remaining...)
 

--- a/extended.go
+++ b/extended.go
@@ -47,7 +47,7 @@ func (e *ExtendedLog) addEntry(level Level, args []interface{}) *Entry {
 func (e *ExtendedLog) addFormattedEntry(
 	level Level, pattern string, args []interface{},
 ) *Entry {
-	fields, remaining := extractTrailingFields(args)
+	fields, remaining := ExtractTrailingFields(args)
 
 	if e.fields != nil && e.fields.contents != nil {
 		i := 0

--- a/fields.go
+++ b/fields.go
@@ -24,7 +24,7 @@ func (f *Fields) renderPlainText() string {
 		if out != "" {
 			out += " "
 		}
-		out += fld.Key + ":" + renderMessage(fld.Val)
+		out += fld.Key + ":" + RenderMessage(fld.Val)
 	}
 	return "[" + out + "] "
 }

--- a/util.go
+++ b/util.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-func extractAllFields(
+func ExtractAllFields(
 	args []interface{},
 ) (fields *Fields, remaining []interface{}) {
 	fields = &Fields{}
@@ -23,7 +23,7 @@ func extractAllFields(
 	return fields, remaining
 }
 
-func extractTrailingFields(
+func ExtractTrailingFields(
 	args []interface{},
 ) (fields *Fields, remaining []interface{}) {
 
@@ -38,7 +38,7 @@ func extractTrailingFields(
 			extractedFs = append([]F{v}, extractedFs...)
 
 		default:
-			remaining = append(remaining, a)
+			remaining = append([]interface{}{a}, remaining...)
 		}
 	}
 
@@ -49,7 +49,7 @@ func extractTrailingFields(
 	return fields, remaining
 }
 
-func renderMessage(args ...interface{}) string {
+func RenderMessage(args ...interface{}) string {
 	message := ""
 	for _, a := range args {
 		if message != "" {


### PR DESCRIPTION
### What?

This is a genuinely stupid bug. When using formatted logging functions (eg. Infof, Printf), arguments would be incorrectly reversed, resulting in confusing and frustrating logging.

This PR adds a fix and a unit test covering the bug.

### Why?

Bugs suck.