### PR TITLE
Render time in a fixed-length format

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -16,15 +16,15 @@ type Entry struct {
 }
 
 const (
-	InvalidTime = "<invalid time>"
+	// TimeFormat is the layout to use when rendering time
+	TimeFormat = "2006-01-02T15:04:05.999"
 )
 
 func (e *Entry) toPlainText() []byte {
-	timeBytes, err := e.Timestamp.MarshalText()
-	if err != nil {
-		timeBytes = []byte(InvalidTime)
-	}
-	return append(append(timeBytes, ' '), e.toPlainTextWithoutTime()...)
+	timeBytes := bytes.NewBufferString(e.Timestamp.Format(TimeFormat)).Bytes()
+	return append(
+		append(timeBytes, ' '),
+		e.toPlainTextWithoutTime()...)
 }
 
 func (e *Entry) toPlainTextWithoutTime() []byte {

--- a/mock.go
+++ b/mock.go
@@ -83,7 +83,7 @@ func (m *MockLog) Message(filters ...filter) (string, bool) {
 // Dump produces a string representation of a mock log, suitable for including
 // in assertion/expectation failure messages
 func (m *MockLog) Dump() string {
-	contents := bytes.NewBuffer([]byte{})
+	var contents bytes.Buffer
 
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()

--- a/mock.go
+++ b/mock.go
@@ -1,6 +1,7 @@
 package lg
 
 import (
+	"bytes"
 	"sync"
 )
 
@@ -82,15 +83,15 @@ func (m *MockLog) Message(filters ...filter) (string, bool) {
 // Dump produces a string representation of a mock log, suitable for including
 // in assertion/expectation failure messages
 func (m *MockLog) Dump() string {
-	contents := ""
+	contents := bytes.NewBuffer([]byte{})
 
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
 
 	for _, e := range m.entries {
-		contents = contents + string(e.toPlainText())
+		contents.Write(e.toPlainText())
 	}
-	return contents
+	return contents.String()
 }
 
 func (m *MockLog) addEntry(level Level, args []interface{}) *Entry {

--- a/mock_test.go
+++ b/mock_test.go
@@ -142,10 +142,11 @@ var _ = Describe("log mocking", func() {
 
 				expected := "info  words\ndebug [foo:bar] things happening\n"
 
-				timePattern := regexp.MustCompile("(^|\n)[0-9T:\\.-]{22,36}Z ")
+				timePattern := regexp.MustCompile("[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{3} ")
 
 				// Trim times out of dumped logs
-				actual := timePattern.ReplaceAllString(mockLog.Dump(), "$1")
+				original := mockLog.Dump()
+				actual := timePattern.ReplaceAllLiteralString(original, "")
 
 				Expect(actual).To(Equal(expected))
 			})


### PR DESCRIPTION
### What?

Update plain-text time rendering to use a fixed-length format.

### Why?

Avoid eye pain when looking at weirdly indented log lines.