### PR TITLE
Add test for order of argument extraction

### DIFF
--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,21 @@
+package lg_test
+
+import (
+	"github.com/autopilothq/lg"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ExtractTrailingFields", func() {
+
+	It("returns remaining args in the correct order", func() {
+		args := []interface{}{1, 2, 3}
+		_, remaining := lg.ExtractTrailingFields(args)
+		Expect(len(remaining)).To(Equal(3))
+		Expect(remaining[0]).To(Equal(1))
+		Expect(remaining[1]).To(Equal(2))
+		Expect(remaining[2]).To(Equal(3))
+	})
+
+})


### PR DESCRIPTION
### What?

Add a test for the order of argument extraction via `ExtractTrailingFields`.

### Why?

This was previously incorrect, the test is to prevent regression.
