### PR TITLE
Add hierarchical prefixes to log entries

### DIFF
--- a/extended.go
+++ b/extended.go
@@ -9,10 +9,8 @@ import (
 func (e ExtendedLog) Extend(f ...F) Log {
 	newFields := Fields{}
 
-	if e.fields.contents != nil {
-		for _, fld := range e.fields.contents {
-			newFields.set(fld)
-		}
+	for _, fld := range e.fields.contents {
+		newFields.set(fld)
 	}
 
 	for _, fld := range f {

--- a/extended.go
+++ b/extended.go
@@ -6,10 +6,10 @@ import (
 
 // Extend returns a new sub logger by extending the current one with
 // extra fields.
-func (e *ExtendedLog) Extend(f ...F) Log {
-	newFields := &Fields{}
+func (e ExtendedLog) Extend(f ...F) Log {
+	newFields := Fields{}
 
-	if e.fields != nil && e.fields.contents != nil {
+	if e.fields.contents != nil {
 		for _, fld := range e.fields.contents {
 			newFields.set(fld)
 		}
@@ -19,20 +19,28 @@ func (e *ExtendedLog) Extend(f ...F) Log {
 		newFields.set(fld)
 	}
 
-	ext := &ExtendedLog{
+	return ExtendedLog{
 		fields: newFields,
+		prefix: e.prefix,
 	}
+}
 
+// ExtendPrefix returns a new sub logger by extending the current one with
+// prefix and extra fields.
+func (e ExtendedLog) ExtendPrefix(prefix string, f ...F) Log {
+	ext := e.Extend(f...).(ExtendedLog)
+	ext.prefix += prefix
 	return ext
 }
 
 // ExtendedLog is a concrete logger interface, optionally with specific fields
 type ExtendedLog struct {
-	fields *Fields
+	prefix string
+	fields Fields
 }
 
-func (e *ExtendedLog) addEntry(level Level, args []interface{}) (*Entry, error) {
-	if e.fields != nil && e.fields.contents != nil {
+func (e ExtendedLog) addEntry(level Level, args []interface{}) (*Entry, error) {
+	if e.fields.contents != nil {
 		i := 0
 		newArgs := make([]interface{}, len(args)+len(e.fields.contents))
 		for ; i < len(e.fields.contents); i++ {
@@ -41,17 +49,17 @@ func (e *ExtendedLog) addEntry(level Level, args []interface{}) (*Entry, error) 
 		for j := 0; j < len(args); i, j = i+1, j+1 {
 			newArgs[i] = args[j]
 		}
-		return addEntry(level, newArgs)
+		return addEntry(level, e.prefix, newArgs)
 	}
-	return addEntry(level, args)
+	return addEntry(level, e.prefix, args)
 }
 
-func (e *ExtendedLog) addFormattedEntry(
+func (e ExtendedLog) addFormattedEntry(
 	level Level, pattern string, args []interface{},
 ) (*Entry, error) {
 	fields, remaining := ExtractTrailingFields(args)
 
-	if e.fields != nil && e.fields.contents != nil {
+	if e.fields.contents != nil {
 		i := 0
 		newArgs := make([]interface{},
 			len(remaining)+len(e.fields.contents)+len(fields.contents))
@@ -64,148 +72,148 @@ func (e *ExtendedLog) addFormattedEntry(
 		for k := 0; k < len(fields.contents); i, k = i+1, k+1 {
 			newArgs[i] = fields.contents[k]
 		}
-		return addFormattedEntry(level, pattern, newArgs)
+		return addFormattedEntry(level, e.prefix, pattern, newArgs)
 	}
-	return addFormattedEntry(level, pattern, args)
+	return addFormattedEntry(level, e.prefix, pattern, args)
 }
 
 // Trace logs a message at trace level
-func (e *ExtendedLog) Trace(args ...interface{}) {
+func (e ExtendedLog) Trace(args ...interface{}) {
 	e.addEntry(LevelTrace, args)
 }
 
 // Traceln logs a message at trace level
-func (e *ExtendedLog) Traceln(args ...interface{}) {
+func (e ExtendedLog) Traceln(args ...interface{}) {
 	e.addEntry(LevelTrace, args)
 }
 
 // Tracef logs a formatted message at trace level
-func (e *ExtendedLog) Tracef(pattern string, args ...interface{}) {
+func (e ExtendedLog) Tracef(pattern string, args ...interface{}) {
 	e.addFormattedEntry(LevelTrace, pattern, args)
 }
 
 // Debug logs a message at debug level
-func (e *ExtendedLog) Debug(args ...interface{}) {
+func (e ExtendedLog) Debug(args ...interface{}) {
 	e.addEntry(LevelDebug, args)
 }
 
 // Debugln logs a message at debug level
-func (e *ExtendedLog) Debugln(args ...interface{}) {
+func (e ExtendedLog) Debugln(args ...interface{}) {
 	e.addEntry(LevelDebug, args)
 }
 
 // Debugf logs a formatted message at debug level
-func (e *ExtendedLog) Debugf(pattern string, args ...interface{}) {
+func (e ExtendedLog) Debugf(pattern string, args ...interface{}) {
 	e.addFormattedEntry(LevelDebug, pattern, args)
 }
 
 // Info logs a message at info level
-func (e *ExtendedLog) Info(args ...interface{}) {
+func (e ExtendedLog) Info(args ...interface{}) {
 	e.addEntry(LevelInfo, args)
 }
 
 // Infoln logs a message at info level
-func (e *ExtendedLog) Infoln(args ...interface{}) {
+func (e ExtendedLog) Infoln(args ...interface{}) {
 	e.addEntry(LevelInfo, args)
 }
 
 // Infof logs a formatted message at info level
-func (e *ExtendedLog) Infof(pattern string, args ...interface{}) {
+func (e ExtendedLog) Infof(pattern string, args ...interface{}) {
 	e.addFormattedEntry(LevelInfo, pattern, args)
 }
 
 // Print logs a message at info level
-func (e *ExtendedLog) Print(args ...interface{}) {
+func (e ExtendedLog) Print(args ...interface{}) {
 	e.addEntry(LevelInfo, args)
 }
 
 // Println logs a message at info level
-func (e *ExtendedLog) Println(args ...interface{}) {
+func (e ExtendedLog) Println(args ...interface{}) {
 	e.addEntry(LevelInfo, args)
 }
 
 // Printf logs a formatted message at info level
-func (e *ExtendedLog) Printf(pattern string, args ...interface{}) {
+func (e ExtendedLog) Printf(pattern string, args ...interface{}) {
 	e.addFormattedEntry(LevelInfo, pattern, args)
 }
 
 // Warn logs a message at warn level
-func (e *ExtendedLog) Warn(args ...interface{}) {
+func (e ExtendedLog) Warn(args ...interface{}) {
 	e.addEntry(LevelWarn, args)
 }
 
 // Warnln logs a message at warn level
-func (e *ExtendedLog) Warnln(args ...interface{}) {
+func (e ExtendedLog) Warnln(args ...interface{}) {
 	e.addEntry(LevelWarn, args)
 }
 
 // Warnf logs a formatted message at warn level
-func (e *ExtendedLog) Warnf(pattern string, args ...interface{}) {
+func (e ExtendedLog) Warnf(pattern string, args ...interface{}) {
 	e.addFormattedEntry(LevelWarn, pattern, args)
 }
 
 // Warning logs a message at warn level
-func (e *ExtendedLog) Warning(args ...interface{}) {
+func (e ExtendedLog) Warning(args ...interface{}) {
 	e.addEntry(LevelWarn, args)
 }
 
 // Warningln logs a message at warn level
-func (e *ExtendedLog) Warningln(args ...interface{}) {
+func (e ExtendedLog) Warningln(args ...interface{}) {
 	e.addEntry(LevelWarn, args)
 }
 
 // Warningf logs a formatted message at warn level
-func (e *ExtendedLog) Warningf(pattern string, args ...interface{}) {
+func (e ExtendedLog) Warningf(pattern string, args ...interface{}) {
 	e.addFormattedEntry(LevelWarn, pattern, args)
 }
 
 // Error logs a message at error level
-func (e *ExtendedLog) Error(args ...interface{}) {
+func (e ExtendedLog) Error(args ...interface{}) {
 	e.addEntry(LevelError, args)
 }
 
 // Errorln logs a message at error level
-func (e *ExtendedLog) Errorln(args ...interface{}) {
+func (e ExtendedLog) Errorln(args ...interface{}) {
 	e.addEntry(LevelError, args)
 }
 
 // Errorf logs a formatted message at error level
-func (e *ExtendedLog) Errorf(pattern string, args ...interface{}) {
+func (e ExtendedLog) Errorf(pattern string, args ...interface{}) {
 	e.addFormattedEntry(LevelError, pattern, args)
 }
 
 // Fatal logs a message at fatal level
-func (e *ExtendedLog) Fatal(args ...interface{}) {
+func (e ExtendedLog) Fatal(args ...interface{}) {
 	e.addEntry(LevelFatal, args)
 	os.Exit(1)
 }
 
 // Fatalln logs a message at fatal level
-func (e *ExtendedLog) Fatalln(args ...interface{}) {
+func (e ExtendedLog) Fatalln(args ...interface{}) {
 	e.addEntry(LevelFatal, args)
 	os.Exit(1)
 }
 
 // Fatalf logs a formatted message at fatal level
-func (e *ExtendedLog) Fatalf(pattern string, args ...interface{}) {
+func (e ExtendedLog) Fatalf(pattern string, args ...interface{}) {
 	e.addFormattedEntry(LevelFatal, pattern, args)
 	os.Exit(1)
 }
 
 // Panic logs a message at fatal level and panics
-func (e *ExtendedLog) Panic(args ...interface{}) {
+func (e ExtendedLog) Panic(args ...interface{}) {
 	entry, _ := e.addEntry(LevelFatal, args)
 	panic(entry.Message)
 }
 
 // Panicln logs a message at fatal level and panics
-func (e *ExtendedLog) Panicln(args ...interface{}) {
+func (e ExtendedLog) Panicln(args ...interface{}) {
 	entry, _ := e.addEntry(LevelFatal, args)
 	panic(entry.Message)
 }
 
 // Panicf logs a formatted message at fatal level and panics
-func (e *ExtendedLog) Panicf(pattern string, args ...interface{}) {
+func (e ExtendedLog) Panicf(pattern string, args ...interface{}) {
 	entry, _ := e.addFormattedEntry(LevelFatal, pattern, args)
 	panic(entry.Message)
 }

--- a/fields.go
+++ b/fields.go
@@ -51,17 +51,12 @@ func (f *Fields) renderPlainText() string {
 }
 
 func (f *Fields) set(fld F) {
-	if f.contents != nil {
-		for _, item := range f.contents {
-			if item.Key == fld.Key {
-				item.Val = fld.Val
-				return
-			}
+	for idx := range f.contents {
+		if f.contents[idx].Key == fld.Key {
+			f.contents[idx].Val = fld.Val
+			return
 		}
-	} else {
-		f.contents = make([]F, 0)
 	}
-
 	f.contents = append(f.contents, fld)
 }
 

--- a/lg.go
+++ b/lg.go
@@ -5,151 +5,158 @@ import (
 )
 
 func Extend(f ...F) Log {
-	fields := &Fields{}
-	ext := &ExtendedLog{fields: fields}
+	fields := Fields{}
 	for _, fld := range f {
 		fields.set(fld)
 	}
-	return ext
+	return ExtendedLog{fields: fields}
+}
+
+func ExtendWithPrefix(prefix string, f ...F) Log {
+	fields := Fields{}
+	for _, fld := range f {
+		fields.set(fld)
+	}
+	return ExtendedLog{fields: fields, prefix: prefix}
 }
 
 // Trace logs a message at trace level
 func Trace(args ...interface{}) {
-	addEntry(LevelTrace, args)
+	addEntry(LevelTrace, "", args)
 }
 
 // Traceln logs a message at trace level
 func Traceln(args ...interface{}) {
-	addEntry(LevelTrace, args)
+	addEntry(LevelTrace, "", args)
 }
 
 // Tracef logs a formatted message at trace level
 func Tracef(pattern string, args ...interface{}) {
-	addFormattedEntry(LevelTrace, pattern, args)
+	addFormattedEntry(LevelTrace, "", pattern, args)
 }
 
 // Debug logs a message at debug level
 func Debug(args ...interface{}) {
-	addEntry(LevelDebug, args)
+	addEntry(LevelDebug, "", args)
 }
 
 // Debugln logs a message at debug level
 func Debugln(args ...interface{}) {
-	addEntry(LevelDebug, args)
+	addEntry(LevelDebug, "", args)
 }
 
 // Debugf logs a formatted message at debug level
 func Debugf(pattern string, args ...interface{}) {
-	addFormattedEntry(LevelDebug, pattern, args)
+	addFormattedEntry(LevelDebug, "", pattern, args)
 }
 
 // Info logs a message at info level
 func Info(args ...interface{}) {
-	addEntry(LevelInfo, args)
+	addEntry(LevelInfo, "", args)
 }
 
 // Infoln logs a message at info level
 func Infoln(args ...interface{}) {
-	addEntry(LevelInfo, args)
+	addEntry(LevelInfo, "", args)
 }
 
 // Infof logs a formatted message at info level
 func Infof(pattern string, args ...interface{}) {
-	addFormattedEntry(LevelInfo, pattern, args)
+	addFormattedEntry(LevelInfo, "", pattern, args)
 }
 
 // Print logs a message at info level
 func Print(args ...interface{}) {
-	addEntry(LevelInfo, args)
+	addEntry(LevelInfo, "", args)
 }
 
 // Println logs a message at info level
 func Println(args ...interface{}) {
-	addEntry(LevelInfo, args)
+	addEntry(LevelInfo, "", args)
 }
 
 // Printf logs a formatted message at info level
 func Printf(pattern string, args ...interface{}) {
-	addFormattedEntry(LevelInfo, pattern, args)
+	addFormattedEntry(LevelInfo, "", pattern, args)
 }
 
 // Warn logs a message at warn level
 func Warn(args ...interface{}) {
-	addEntry(LevelWarn, args)
+	addEntry(LevelWarn, "", args)
 }
 
 // Warnln logs a message at warn level
 func Warnln(args ...interface{}) {
-	addEntry(LevelWarn, args)
+	addEntry(LevelWarn, "", args)
 }
 
 // Warnf logs a formatted message at warn level
 func Warnf(pattern string, args ...interface{}) {
-	addFormattedEntry(LevelWarn, pattern, args)
+	addFormattedEntry(LevelWarn, "", pattern, args)
 }
 
 // Warning logs a message at warn level
 func Warning(args ...interface{}) {
-	addEntry(LevelWarn, args)
+	addEntry(LevelWarn, "", args)
 }
 
 // Warningln logs a message at warn level
 func Warningln(args ...interface{}) {
-	addEntry(LevelWarn, args)
+	addEntry(LevelWarn, "", args)
 }
 
 // Warningf logs a formatted message at warn level
 func Warningf(pattern string, args ...interface{}) {
-	addFormattedEntry(LevelWarn, pattern, args)
+	addFormattedEntry(LevelWarn, "", pattern, args)
 }
 
 // Error logs a message at error level
 func Error(args ...interface{}) {
-	addEntry(LevelError, args)
+	addEntry(LevelError, "", args)
 }
 
 // Errorln logs a message at error level
 func Errorln(args ...interface{}) {
-	addEntry(LevelError, args)
+	addEntry(LevelError, "", args)
 }
 
 // Errorf logs a formatted message at error level
 func Errorf(pattern string, args ...interface{}) {
-	addFormattedEntry(LevelError, pattern, args)
+	addFormattedEntry(LevelError, "", pattern, args)
 }
 
 // Fatal logs a message at fatal level
 func Fatal(args ...interface{}) {
-	addEntry(LevelFatal, args)
+	addEntry(LevelFatal, "", args)
 	os.Exit(1)
 }
 
 // Fatalln logs a message at fatal level
 func Fatalln(args ...interface{}) {
-	addEntry(LevelFatal, args)
+	addEntry(LevelFatal, "", args)
 	os.Exit(1)
 }
 
 // Fatalf logs a formatted message at fatal level
 func Fatalf(pattern string, args ...interface{}) {
-	addFormattedEntry(LevelFatal, pattern, args)
+	addFormattedEntry(LevelFatal, "", pattern, args)
 	os.Exit(1)
 }
 
 // Panic logs a message at fatal level and panics
 func Panic(args ...interface{}) {
-	entry, _ := addEntry(LevelFatal, args)
+	entry, _ := addEntry(LevelFatal, "", args)
 	panic(entry.Message)
 }
 
 // Panicln logs a message at fatal level and panics
 func Panicln(args ...interface{}) {
-	entry, _ := addEntry(LevelFatal, args)
+	entry, _ := addEntry(LevelFatal, "", args)
 	panic(entry.Message)
 }
 
 // Panicf logs a formatted message at fatal level and panics
 func Panicf(pattern string, args ...interface{}) {
-	entry, _ := addFormattedEntry(LevelFatal, pattern, args)
+	entry, _ := addFormattedEntry(LevelFatal, "", pattern, args)
 	panic(entry.Message)
 }

--- a/log.go
+++ b/log.go
@@ -39,4 +39,5 @@ type Log interface {
 	Panicf(pattern string, args ...interface{})
 
 	Extend(f ...F) Log
+	ExtendPrefix(prefix string, f ...F) Log
 }

--- a/mock.go
+++ b/mock.go
@@ -7,8 +7,10 @@ import (
 
 type MockLog struct {
 	prefix  string
+	fields  Fields
 	entries []*Entry
 	mutex   sync.RWMutex
+	parent  *MockLog
 }
 
 type filter interface {
@@ -20,6 +22,9 @@ func Mock() *MockLog {
 }
 
 func (m *MockLog) Count(filters ...filter) (count int) {
+	if m.parent != nil {
+		return m.parent.Count(filters...)
+	}
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
 
@@ -40,6 +45,9 @@ func (m *MockLog) Count(filters ...filter) (count int) {
 }
 
 func (m *MockLog) Messages(filters ...filter) []string {
+	if m.parent != nil {
+		return m.parent.Messages(filters...)
+	}
 	messages := make([]string, 0)
 
 	m.mutex.RLock()
@@ -62,6 +70,9 @@ func (m *MockLog) Messages(filters ...filter) []string {
 }
 
 func (m *MockLog) Message(filters ...filter) (string, bool) {
+	if m.parent != nil {
+		return m.parent.Message(filters...)
+	}
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
 
@@ -84,6 +95,9 @@ func (m *MockLog) Message(filters ...filter) (string, bool) {
 // Dump produces a string representation of a mock log, suitable for including
 // in assertion/expectation failure messages
 func (m *MockLog) Dump() string {
+	if m.parent != nil {
+		return m.parent.Dump()
+	}
 	var contents bytes.Buffer
 
 	m.mutex.RLock()
@@ -95,8 +109,23 @@ func (m *MockLog) Dump() string {
 	return contents.String()
 }
 
-func (m *MockLog) addEntry(level Level, args []interface{}) *Entry {
-	entry := makeEntry(level, m.prefix, args)
+func (m *MockLog) mergeArgs(args []interface{}) []interface{} {
+	if m.fields.contents == nil {
+		return args
+	}
+	mergedArgs := make([]interface{}, 0, len(args)+len(m.fields.contents))
+	for _, f := range m.fields.contents {
+		mergedArgs = append(mergedArgs, f)
+	}
+	return append(mergedArgs, args...)
+}
+
+func (m *MockLog) addEntry(level Level, prefix string,
+	args []interface{}) *Entry {
+	if m.parent != nil {
+		return m.parent.addEntry(level, prefix, args)
+	}
+	entry := makeEntry(level, prefix, args)
 
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
@@ -106,9 +135,13 @@ func (m *MockLog) addEntry(level Level, args []interface{}) *Entry {
 }
 
 func (m *MockLog) addFormattedEntry(
-	level Level, pattern string, args []interface{},
+	level Level, prefix string, pattern string, args []interface{},
 ) *Entry {
-	entry := makeFormattedEntry(level, m.prefix, pattern, args)
+	if m.parent != nil {
+		return m.parent.addFormattedEntry(level, prefix, pattern, args)
+	}
+
+	entry := makeFormattedEntry(level, prefix, pattern, args)
 
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
@@ -120,150 +153,166 @@ func (m *MockLog) addFormattedEntry(
 // Extend returns a new sub logger by extending the current one with
 // extra fields.
 func (m *MockLog) Extend(f ...F) Log {
-	// TODO: incorporate fields properly
-	return m
+	newFields := Fields{}
+
+	for _, fld := range m.fields.contents {
+		newFields.set(fld)
+	}
+
+	for _, fld := range f {
+		newFields.set(fld)
+	}
+
+	ext := &MockLog{
+		fields: newFields,
+	}
+	if m.parent == nil {
+		ext.parent = m
+	} else {
+		ext.parent = m.parent
+	}
+	return ext
 }
 
 // ExtendPrefix returns a new sub logger by extending the current one with
 // prefix and extra fields.
 func (m *MockLog) ExtendPrefix(prefix string, f ...F) Log {
-	ext := &MockLog{
-		prefix: m.prefix + prefix,
-	}
+	ext := m.Extend(f...).(*MockLog)
+	ext.prefix += prefix
 	return ext
 }
 
 // Trace logs a message at trace level
 func (m *MockLog) Trace(args ...interface{}) {
-	m.addEntry(LevelTrace, args)
+	m.addEntry(LevelTrace, m.prefix, m.mergeArgs(args))
 }
 
 // Traceln logs a message at trace level
 func (m *MockLog) Traceln(args ...interface{}) {
-	m.addEntry(LevelTrace, args)
+	m.addEntry(LevelTrace, m.prefix, m.mergeArgs(args))
 }
 
 // Tracef logs a formatted message at trace level
 func (m *MockLog) Tracef(pattern string, args ...interface{}) {
-	m.addFormattedEntry(LevelTrace, pattern, args)
+	m.addFormattedEntry(LevelTrace, m.prefix, pattern, m.mergeArgs(args))
 }
 
 // Debug logs a message at debug level
 func (m *MockLog) Debug(args ...interface{}) {
-	m.addEntry(LevelDebug, args)
+	m.addEntry(LevelDebug, m.prefix, m.mergeArgs(args))
 }
 
 // Debugln logs a message at debug level
 func (m *MockLog) Debugln(args ...interface{}) {
-	m.addEntry(LevelDebug, args)
+	m.addEntry(LevelDebug, m.prefix, m.mergeArgs(args))
 }
 
 // Debugf logs a formatted message at debug level
 func (m *MockLog) Debugf(pattern string, args ...interface{}) {
-	m.addFormattedEntry(LevelDebug, pattern, args)
+	m.addFormattedEntry(LevelDebug, m.prefix, pattern, m.mergeArgs(args))
 }
 
 // Info logs a message at info level
 func (m *MockLog) Info(args ...interface{}) {
-	m.addEntry(LevelInfo, args)
+	m.addEntry(LevelInfo, m.prefix, m.mergeArgs(args))
 }
 
 // Infoln logs a message at info level
 func (m *MockLog) Infoln(args ...interface{}) {
-	m.addEntry(LevelInfo, args)
+	m.addEntry(LevelInfo, m.prefix, m.mergeArgs(args))
 }
 
 // Infof logs a formatted message at info level
 func (m *MockLog) Infof(pattern string, args ...interface{}) {
-	m.addFormattedEntry(LevelInfo, pattern, args)
+	m.addFormattedEntry(LevelInfo, m.prefix, pattern, m.mergeArgs(args))
 }
 
 // Print logs a message at info level
 func (m *MockLog) Print(args ...interface{}) {
-	m.addEntry(LevelInfo, args)
+	m.addEntry(LevelInfo, m.prefix, m.mergeArgs(args))
 }
 
 // Println logs a message at info level
 func (m *MockLog) Println(args ...interface{}) {
-	m.addEntry(LevelInfo, args)
+	m.addEntry(LevelInfo, m.prefix, m.mergeArgs(args))
 }
 
 // Printf logs a formatted message at info level
 func (m *MockLog) Printf(pattern string, args ...interface{}) {
-	m.addFormattedEntry(LevelInfo, pattern, args)
+	m.addFormattedEntry(LevelInfo, m.prefix, pattern, m.mergeArgs(args))
 }
 
 // Warn logs a message at warn level
 func (m *MockLog) Warn(args ...interface{}) {
-	m.addEntry(LevelWarn, args)
+	m.addEntry(LevelWarn, m.prefix, m.mergeArgs(args))
 }
 
 // Warnln logs a message at warn level
 func (m *MockLog) Warnln(args ...interface{}) {
-	m.addEntry(LevelWarn, args)
+	m.addEntry(LevelWarn, m.prefix, m.mergeArgs(args))
 }
 
 // Warnf logs a formatted message at warn level
 func (m *MockLog) Warnf(pattern string, args ...interface{}) {
-	m.addFormattedEntry(LevelWarn, pattern, args)
+	m.addFormattedEntry(LevelWarn, m.prefix, pattern, m.mergeArgs(args))
 }
 
 // Warning logs a message at warn level
 func (m *MockLog) Warning(args ...interface{}) {
-	m.addEntry(LevelWarn, args)
+	m.addEntry(LevelWarn, m.prefix, m.mergeArgs(args))
 }
 
 // Warningln logs a message at warn level
 func (m *MockLog) Warningln(args ...interface{}) {
-	m.addEntry(LevelWarn, args)
+	m.addEntry(LevelWarn, m.prefix, m.mergeArgs(args))
 }
 
 // Warningf logs a formatted message at warn level
 func (m *MockLog) Warningf(pattern string, args ...interface{}) {
-	m.addFormattedEntry(LevelWarn, pattern, args)
+	m.addFormattedEntry(LevelWarn, m.prefix, pattern, m.mergeArgs(args))
 }
 
 // Error logs a message at error level
 func (m *MockLog) Error(args ...interface{}) {
-	m.addEntry(LevelError, args)
+	m.addEntry(LevelError, m.prefix, m.mergeArgs(args))
 }
 
 // Errorln logs a message at error level
 func (m *MockLog) Errorln(args ...interface{}) {
-	m.addEntry(LevelError, args)
+	m.addEntry(LevelError, m.prefix, m.mergeArgs(args))
 }
 
 // Errorf logs a formatted message at error level
 func (m *MockLog) Errorf(pattern string, args ...interface{}) {
-	m.addFormattedEntry(LevelError, pattern, args)
+	m.addFormattedEntry(LevelError, m.prefix, pattern, m.mergeArgs(args))
 }
 
 // Fatal logs a message at fatal level
 func (m *MockLog) Fatal(args ...interface{}) {
-	panic(m.addEntry(LevelFatal, args).Message)
+	panic(m.addEntry(LevelFatal, m.prefix, m.mergeArgs(args)).Message)
 }
 
 // Fatalln logs a message at fatal level
 func (m *MockLog) Fatalln(args ...interface{}) {
-	panic(m.addEntry(LevelFatal, args).Message)
+	panic(m.addEntry(LevelFatal, m.prefix, m.mergeArgs(args)).Message)
 }
 
 // Fatalf logs a formatted message at fatal level
 func (m *MockLog) Fatalf(pattern string, args ...interface{}) {
-	panic(m.addFormattedEntry(LevelError, pattern, args).Message)
+	panic(m.addFormattedEntry(LevelError, m.prefix, pattern, m.mergeArgs(args)).Message)
 }
 
 // Panic logs a message at fatal level and panics
 func (m *MockLog) Panic(args ...interface{}) {
-	panic(m.addEntry(LevelFatal, args).Message)
+	panic(m.addEntry(LevelFatal, m.prefix, m.mergeArgs(args)).Message)
 }
 
 // Panicln logs a message at fatal level and panics
 func (m *MockLog) Panicln(args ...interface{}) {
-	panic(m.addEntry(LevelFatal, args).Message)
+	panic(m.addEntry(LevelFatal, m.prefix, m.mergeArgs(args)).Message)
 }
 
 // Panicf logs a formatted message at fatal level and panics
 func (m *MockLog) Panicf(pattern string, args ...interface{}) {
-	panic(m.addFormattedEntry(LevelFatal, pattern, args).Message)
+	panic(m.addFormattedEntry(LevelFatal, m.prefix, pattern, m.mergeArgs(args)).Message)
 }

--- a/mock.go
+++ b/mock.go
@@ -6,6 +6,7 @@ import (
 )
 
 type MockLog struct {
+	prefix  string
 	entries []*Entry
 	mutex   sync.RWMutex
 }
@@ -95,7 +96,7 @@ func (m *MockLog) Dump() string {
 }
 
 func (m *MockLog) addEntry(level Level, args []interface{}) *Entry {
-	entry := makeEntry(level, args)
+	entry := makeEntry(level, m.prefix, args)
 
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
@@ -107,7 +108,7 @@ func (m *MockLog) addEntry(level Level, args []interface{}) *Entry {
 func (m *MockLog) addFormattedEntry(
 	level Level, pattern string, args []interface{},
 ) *Entry {
-	entry := makeFormattedEntry(level, pattern, args)
+	entry := makeFormattedEntry(level, m.prefix, pattern, args)
 
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
@@ -116,9 +117,19 @@ func (m *MockLog) addFormattedEntry(
 	return entry
 }
 
+// Extend returns a new sub logger by extending the current one with
+// extra fields.
 func (m *MockLog) Extend(f ...F) Log {
 	// TODO: incorporate fields properly
 	return m
+}
+
+// ExtendPrefix returns a new sub logger by extending the current one with
+// prefix and extra fields.
+func (m *MockLog) ExtendPrefix(prefix string, f ...F) Log {
+	ext := m.Extend(f...).(*MockLog)
+	ext.prefix += prefix
+	return ext
 }
 
 // Trace logs a message at trace level

--- a/mock.go
+++ b/mock.go
@@ -127,8 +127,9 @@ func (m *MockLog) Extend(f ...F) Log {
 // ExtendPrefix returns a new sub logger by extending the current one with
 // prefix and extra fields.
 func (m *MockLog) ExtendPrefix(prefix string, f ...F) Log {
-	ext := m.Extend(f...).(*MockLog)
-	ext.prefix += prefix
+	ext := &MockLog{
+		prefix: m.prefix + prefix,
+	}
 	return ext
 }
 

--- a/output.go
+++ b/output.go
@@ -177,8 +177,8 @@ func callHooks(entry *Entry) (err error) {
 	return err
 }
 
-func addEntry(level Level, args []interface{}) (*Entry, error) {
-	entry := makeEntry(level, args)
+func addEntry(level Level, prefix string, args []interface{}) (*Entry, error) {
+	entry := makeEntry(level, prefix, args)
 	if err := callHooks(entry); err != nil {
 		return nil, err
 	}
@@ -187,9 +187,9 @@ func addEntry(level Level, args []interface{}) (*Entry, error) {
 }
 
 func addFormattedEntry(
-	level Level, pattern string, args []interface{},
+	level Level, prefix string, pattern string, args []interface{},
 ) (*Entry, error) {
-	entry := makeFormattedEntry(level, pattern, args)
+	entry := makeFormattedEntry(level, prefix, pattern, args)
 	if err := callHooks(entry); err != nil {
 		return nil, err
 	}

--- a/util.go
+++ b/util.go
@@ -7,8 +7,7 @@ import (
 
 func ExtractAllFields(
 	args []interface{},
-) (fields *Fields, remaining []interface{}) {
-	fields = &Fields{}
+) (fields Fields, remaining []interface{}) {
 	remaining = make([]interface{}, 0)
 
 	for _, a := range args {
@@ -26,10 +25,9 @@ func ExtractAllFields(
 
 func ExtractTrailingFields(
 	args []interface{},
-) (fields *Fields, remaining []interface{}) {
+) (fields Fields, remaining []interface{}) {
 
 	extractedFs := make([]F, 0)
-	fields = &Fields{}
 	remaining = make([]interface{}, 0)
 
 	for i := len(args) - 1; i >= 0; i-- {


### PR DESCRIPTION
## What?

Add hierarchical prefixes to log entries

## Checklist

- [X] Tests for the changes have been added and `make test` passes (for bug fixes / features)


## Why?

It's easier to query logs via systems like ElasticSearch, if you have hierarchical prefixes.

