### PR TITLE
Quote strings in text output

### DIFF
--- a/encoding/text/encoder.go
+++ b/encoding/text/encoder.go
@@ -3,6 +3,7 @@ package text
 import (
 	"encoding/json"
 	"math"
+	"strconv"
 	"time"
 
 	"github.com/autopilothq/lg/encoding/buffer"
@@ -224,6 +225,6 @@ func (e *Encoder) addSeparator() {
 // AddString adds a string to the encoded buffer
 func (e *Encoder) AddString(s string) error {
 	e.addSeparator()
-	e.buf.AppendString(s)
+	e.buf.AppendString(strconv.Quote(s))
 	return nil
 }

--- a/encoding/text/encoder_test.go
+++ b/encoding/text/encoder_test.go
@@ -116,7 +116,7 @@ var _ = Describe("log encoding Text", func() {
 	Describe("AddString()", func() {
 		It("adds a string", func() {
 			Expect(enc.AddString("wut!?")).To(Succeed())
-			Expect(enc.String()).To(Equal(`wut!?`))
+			Expect(enc.String()).To(Equal(`"wut!?"`))
 		})
 	})
 })

--- a/mock_test.go
+++ b/mock_test.go
@@ -140,7 +140,7 @@ var _ = Describe("log mocking", func() {
 				log.Print("words")
 				log.Debug("things happening", lg.F{"foo", "bar"})
 
-				expected := "info  words\ndebug [foo:bar] things happening\n"
+				expected := "info  words\ndebug [foo:\"bar\"] things happening\n"
 
 				timePattern := regexp.MustCompile("[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{3} ")
 


### PR DESCRIPTION
## What?

quote all string in text output

## Checklist

- [x] Tests for the changes have been added and `make test` passes (for bug fixes / features)

## Why?

it is easier to read when strings are quoted.
