### PR TITLE
Add auto prefix delimiters

### DIFF
--- a/extended.go
+++ b/extended.go
@@ -27,7 +27,11 @@ func (e ExtendedLog) Extend(f ...F) Log {
 // prefix and extra fields.
 func (e ExtendedLog) ExtendPrefix(prefix string, f ...F) Log {
 	ext := e.Extend(f...).(ExtendedLog)
-	ext.prefix += prefix
+	if ext.prefix == "" {
+		ext.prefix = prefix
+	} else {
+		ext.prefix += prefixDelimiter + prefix
+	}
 	return ext
 }
 

--- a/lg.go
+++ b/lg.go
@@ -12,6 +12,12 @@ func Extend(f ...F) Log {
 	return ExtendedLog{fields: fields}
 }
 
+var prefixDelimiter = "."
+
+func SetPrefixDelimiter(delimiter string) {
+	prefixDelimiter = delimiter
+}
+
 func ExtendWithPrefix(prefix string, f ...F) Log {
 	fields := Fields{}
 	for _, fld := range f {


### PR DESCRIPTION
Add auto prefix delimiters, eg:
`lg.ExtendPrefix("Server").ExtendPrefix("Cluster")` will add `Server.Cluster` prefix