### PR TITLE
Restrict log levels per prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,10 @@ handler = func(e *lg.Entry) {
   fmt.Println(e.Timestamp, e.Level.String(), e.Message, e.Fields)
 }
 
-lg.AddHook(handler)
+hookID := lg.AddHook(handler)
 
-// A hook can be removed by passing the same handler function to lg.RemoveHook:
-// lg.RemoveHook(handler)
+// A hook can be removed by passing the hookId to lg.RemoveHook:
+// lg.RemoveHook(hookID)
 ```
 
 

--- a/options.go
+++ b/options.go
@@ -1,21 +1,35 @@
 package lg
 
+import (
+	"fmt"
+	"regexp"
+)
+
 type OutputFormat uint
+
+type PrefixLevel struct {
+	prefix   string
+	minLevel Level
+}
+
+type Options struct {
+	minLevels []PrefixLevel
+	format    OutputFormat
+}
 
 const (
 	FormatPlainText OutputFormat = iota
 	FormatJSON
 )
 
-type Options struct {
-	minLevel Level
-	format   OutputFormat
-}
+var (
+	prefixLevelPattern = regexp.MustCompile("(?:([^\\s,()]+)=)?(trace|debug|info|warn|error|fatal)")
+)
 
 func makeOptions(opts ...func(*Options)) *Options {
 	result := &Options{
-		format:   FormatPlainText,
-		minLevel: LevelTrace,
+		format:    FormatPlainText,
+		minLevels: nil,
 	}
 	for _, opt := range opts {
 		opt(result)
@@ -37,6 +51,32 @@ func JSON() func(*Options) {
 
 func MinLevel(l Level) func(*Options) {
 	return func(o *Options) {
-		o.minLevel = l
+		if o.minLevels == nil {
+			o.minLevels = make([]PrefixLevel, 1)
+			o.minLevels[0] = PrefixLevel{prefix: "", minLevel: l}
+		} else if len(o.minLevels) == 0 {
+			o.minLevels = append(o.minLevels, PrefixLevel{prefix: "", minLevel: l})
+		} else {
+			last := o.minLevels[len(o.minLevels)-1]
+			if last.prefix == "" {
+				last.minLevel = l
+			} else {
+				o.minLevels = append(o.minLevels, PrefixLevel{prefix: "", minLevel: l})
+			}
+		}
+	}
+}
+
+func Levels(levels string) func(*Options) {
+	return func(o *Options) {
+		matches := prefixLevelPattern.FindAllStringSubmatch(levels, -1)
+		o.minLevels = make([]PrefixLevel, len(matches))
+		for n, match := range matches {
+			l, err := ParseLevel(match[2])
+			if err != nil {
+				panic(fmt.Errorf("Unparsable levels string '%s': '%s' is not a valid level", levels, match[2]))
+			}
+			o.minLevels[n] = PrefixLevel{prefix: match[1], minLevel: l}
+		}
 	}
 }

--- a/options.go
+++ b/options.go
@@ -67,6 +67,23 @@ func MinLevel(l Level) func(*Options) {
 	}
 }
 
+// Levels specifies the minimum log level for an Output. Levels can be specfied by log prefix.
+//
+// Examples:
+//
+//   // Show debug level and above on stdout
+//   lg.SetOutput(os.Stdout, lg.Levels("debug"))
+//
+//   // Show info level and above by default, but only show warn and above
+//   // for any logs from the "Server" prefix, including sub-prefixes.
+//   lg.SetOutput(os.Stdout, lg.Levels("(Server=warn) info"))
+//
+//   // Show errors and above, except for logs with the "Request" prefix,
+//   // which will show trace and above
+//   lg.SetOutput(os.Stdout, lg.Levels("(Request=trace) error"))
+//
+// The levels string is evaluated left-to-right, so more specific prefixes
+// should be to the left of more general ones.
 func Levels(levels string) func(*Options) {
 	return func(o *Options) {
 		matches := prefixLevelPattern.FindAllStringSubmatch(levels, -1)

--- a/output_test.go
+++ b/output_test.go
@@ -1,0 +1,63 @@
+package lg_test
+
+import (
+	"bytes"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/autopilothq/lg"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type TestLogOutput struct {
+	bytes.Buffer
+}
+
+var (
+	lastEntryPattern = regexp.MustCompile("\\S+\n$")
+)
+
+func (tlo *TestLogOutput) lastEntry() string {
+	return strings.TrimSpace(lastEntryPattern.FindString(tlo.String()))
+}
+
+var _ = Describe("log output", func() {
+
+	var tlo *TestLogOutput
+
+	BeforeEach(func() {
+		tlo = &TestLogOutput{}
+		lg.RemoveOutput(os.Stdout)
+		lg.AddOutput(tlo, lg.Levels("Foo.Bar=info (Bar=error)(Foo=error) (trace)"))
+	})
+
+	AfterEach(func() {
+		lg.RemoveOutput(tlo)
+		lg.AddOutput(os.Stdout)
+	})
+
+	It("should be filtered by prefix and level", func() {
+		fooLog := lg.ExtendWithPrefix("Foo")
+		foobarLog := fooLog.ExtendPrefix("Bar")
+		barLog := lg.ExtendWithPrefix("Bar")
+		lg.Debug("1")
+		Expect(tlo.lastEntry()).To(Equal("1"))
+		lg.Warn("2")
+		Expect(tlo.lastEntry()).To(Equal("2"))
+		fooLog.Error("3")
+		Expect(tlo.lastEntry()).To(Equal("3"))
+		fooLog.Trace("4")
+		Expect(tlo.lastEntry()).To(Equal("3"))
+		foobarLog.Info("5")
+		Expect(tlo.lastEntry()).To(Equal("5"))
+		foobarLog.Debug("6")
+		Expect(tlo.lastEntry()).To(Equal("5"))
+		barLog.Trace("7")
+		Expect(tlo.lastEntry()).To(Equal("5"))
+		barLog.Warn("8")
+		Expect(tlo.lastEntry()).To(Equal("5"))
+	})
+})


### PR DESCRIPTION
### What?

Is is possible to filter outputs by log level, eg:

```
   lg.SetOutput(os.Stdout, lg.MinLevel(lg.LevelInfo))
```

This PR allows the minimum log level to be specified per log prefix, eg:

```
  // Show 'trace' logs by default, but filter logs with the Gossip prefix
  // so only info and above will be shown
  lg.SetOutput(os.Stdout, lg.Levels("(Gossip=info) trace")

  gossipLog = lg.ExtendWithPrefix("Gossip")

  lg.Trace("foobar") // will be logged to stdout

  gossipLog.Trace("goobar") // will NOT be logged to stdout
```

### Why?

Log prefixes are a newer addition to lg, now that we have them we can use them for finer-grained control of outputs.
